### PR TITLE
#9 Update command to execute on server

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,8 @@ chmod 700 "$SSHPATH"
 chmod 600 "$SSHPATH/known_hosts"
 chmod 600 "$SSHPATH/deploy_key"
 
-echo "$INPUT_COMMAND exit" > $HOME/shell.sh
+echo "$INPUT_COMMAND" > $HOME/shell.sh
+echo "exit" >> $HOME/shell.sh
 cat $HOME/shell.sh
 
 echo Start Run Command


### PR DESCRIPTION
As mentioned in https://github.com/fifsky/ssh-action/issues/9 then command that is being ran appends the "exit" command incorrectly. I've updated the script that creates the commands to run on the server so that this doesn't happen going forward. 