### PR TITLE
fix: SSH connection quote issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,5 +38,5 @@ if [ "$INPUT_PASS" = "" ]
 then
   sh -c "ssh $INPUT_ARGS -i $KEYFILE -o StrictHostKeyChecking=no -p $INPUT_PORT ${INPUT_USER}@${INPUT_HOST} < $HOME/shell.sh"
 else
-  sh -c "sshpass -p "$INPUT_PASS" ssh $INPUT_ARGS -o StrictHostKeyChecking=no -p $INPUT_PORT ${INPUT_USER}@${INPUT_HOST} < $HOME/shell.sh"
+  sh -c "sshpass -p '$INPUT_PASS' ssh $INPUT_ARGS -o StrictHostKeyChecking=no -p $INPUT_PORT ${INPUT_USER}@${INPUT_HOST} < $HOME/shell.sh"
 fi


### PR DESCRIPTION
When we use strong password including symbols like "<" it doesn't proceed the request. Double quote " doesn't work with specific passwords. Single ' ' is  working.